### PR TITLE
DOPS-6403 Don't push edge tag on PR build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,11 @@ runs:
           MAJOR=${MINOR%.*}
           TAGS="${DOCKER_IMAGE}:v${VERSION},${DOCKER_IMAGE}:version-${VERSION},${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
         else
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:edge"
+          if [[ "$VERSION" == PR-* ]]; then
+            TAGS="${DOCKER_IMAGE}:${VERSION}"
+          else
+            TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:edge"
+          fi
           if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${TAGS},${DOCKER_IMAGE}:${REF_NAME_TAG}-${COMMIT_SHA:0:7}-$(date --utc +%Y%m%d%H%M%SZ)"
           fi


### PR DESCRIPTION
When the version begin with PR- (ex, PR-123), never push the edge tag.